### PR TITLE
Added --repository-url to try and fix permissions

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -4,7 +4,7 @@ set -ev  # Needed in order for Travis CI to report failure
 if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_EVENT_TYPE == "push" ]
 then
   python setup.py sdist bdist_wheel
-  twine upload  -u $PYPI_USERNAME -p $PYPI_PASSWORD dist/*
+  twine upload  --repository-url https://pypi.python.org/pypi -u $PYPI_USERNAME -p $PYPI_PASSWORD dist/*
 else
   echo "No releases published for this build!"
 fi


### PR DESCRIPTION
Getting the following error on Travis when try to push distributions to PyPI server...

```bash
HTTPError: 403 Client Error: Invalid or non-existent authentication information. for url: https://upload.pypi.org/legacy/
```