### PR TITLE
Update BEA base url

### DIFF
--- a/pybea/api.py
+++ b/pybea/api.py
@@ -11,7 +11,7 @@ class Request(dict):
 
     _response = None
 
-    base_url = 'http://www.bea.gov/api/data'
+    base_url = 'https://apps.bea.gov/api/data/'
 
     valid_formats = ['JSON', 'XML']
 


### PR DESCRIPTION
As described here: https://apps.bea.gov/api/signup/ the API is now hosted in a new subdomain: https://apps.bea.gov